### PR TITLE
use Dataset.from_tensor_slices for synthetic input

### DIFF
--- a/tftrt/examples/image-classification/image_classification.py
+++ b/tftrt/examples/image-classification/image_classification.py
@@ -132,13 +132,17 @@ def run(frozen_graph, model, data_files, batch_size,
                 loc=112, scale=70,
                 size=(batch_size, input_height, input_width, 3)).astype(np.float32)
             features = np.clip(features, 0.0, 255.0)
-            features = tf.identity(tf.constant(features))
             labels = np.random.randint(
                 low=0,
                 high=get_netdef(model).get_num_classes(),
                 size=(batch_size),
                 dtype=np.int32)
             labels = tf.identity(tf.constant(labels))
+            dataset = tf.data.Dataset.from_tensor_slices((features,labels))
+            dataset = dataset.repeat(count=None)
+            dataset = dataset.batch(batch_size)
+            iterator = dataset.make_one_shot_iterator()
+            features,labels = iterator.get_next()
         else:
             if mode == 'validation':
                 dataset = tf.data.TFRecordDataset(data_files)


### PR DESCRIPTION
tensorflow will keep the constant on the CPU when using tf.constant() as input for synthetic mode. and there is no memcpy HtoD from iteration to iteration. 
Fixed by using Dataset.from_tensor_slices.