### PR TITLE
Fix links to TF-TRT docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Documentation for TensorRT in TensorFlow (TF-TRT)
 
-The documentaion on how to accelerate inference in TensorFlow with TensorRT (TF-TRT) is here: https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html
+The documentaion on how to accelerate inference in TensorFlow with TensorRT (TF-TRT) is here: https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html
 
 # Examples for TensorRT in TensorFlow (TF-TRT)
 
@@ -12,7 +12,7 @@ that optimizes TensorFlow graphs using
 [TensorRT](https://developer.nvidia.com/tensorrt).
 We have used these examples to verify the accuracy and
 performance of TF-TRT. For more information see
-[Verified Models](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html#verified-models).
+[Verified Models](https://docs.nvidia.com/deeplearning/dgx//tf-trt-user-guide/index.html#verified-models).
 
 ## Examples
 
@@ -50,7 +50,7 @@ Installation instructions for compatibility with TensorFlow are provided on the
 
 ## Documentation
 
-[TF-TRT documentaion](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html)
+[TF-TRT documentaion](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html)
 gives an overview of the supported functionalities, provides tutorials
 and verified models, explains best practices with troubleshooting guides.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ that optimizes TensorFlow graphs using
 [TensorRT](https://developer.nvidia.com/tensorrt).
 We have used these examples to verify the accuracy and
 performance of TF-TRT. For more information see
-[Verified Models](https://docs.nvidia.com/deeplearning/dgx//tf-trt-user-guide/index.html#verified-models).
+[Verified Models](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html#verified-models).
 
 ## Examples
 

--- a/tftrt/examples/image-classification/README.md
+++ b/tftrt/examples/image-classification/README.md
@@ -12,7 +12,7 @@ This causes the script to apply TensorRT inference optimization to speed up
 execution for portions of the model's graph where supported, and to fall back on
 native TensorFlow for layers and operations which are not supported.  See
 [Accelerating Inference In TensorFlow With TensorRT User
-Guide](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html) for
+Guide](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html) for
 more information.
 
 When using the TF-TRT integration flag, you can use the precision option
@@ -42,7 +42,7 @@ We have verified the following models.
 
 For the accuracy numbers of these models on the
 ImageNet validation dataset, see
-[Verified Models](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html#verified-models).
+[Verified Models](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html#verified-models).
 
 ## Setup
 
@@ -97,7 +97,7 @@ replacing `/path/to/tensorflow_models` with the path to your `tensorflow/models`
 repository).
 
 Also see [Setting Up The Environment
-](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html#image-class-envirn)
+](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html#image-class-envirn)
 for more information.
 
 ### Data
@@ -127,7 +127,7 @@ or
   the validation set.
 
 Also see [Obtaining The ImageNet Data
-](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html#image-class-data)
+](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html#image-class-data)
 for more information.
 
 ## Running the examples as a Jupyter notebook
@@ -181,7 +181,7 @@ Where:
 Run with `--help` to see all available options.
 
 Also see [General Script Usage
-](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html#image-class-usage)
+](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html#image-class-usage)
 for more information.
 
 ## Output
@@ -215,9 +215,9 @@ time(s)(trt_conversion): ***
 
 Note: For a list of supported operations that can be converted to a TensorRT
 graph, see the [Supported
-Ops](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html#support-ops)
+Ops](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html#support-ops)
 section of the [Accelerating Inference In TensorFlow With TensorRT User
-Guide](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html).
+Guide](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html).
 
 The script then begins running inference on the ImageNet validation set,
 displaying run times of each iteration after the interval defined by the

--- a/tftrt/examples/image-classification/image_classification.ipynb
+++ b/tftrt/examples/image-classification/image_classification.ipynb
@@ -34,7 +34,7 @@
     "* Inception v3\n",
     "* Inception v4\n",
     "\n",
-    "For the accuracy numbers of these models on the ImageNet validation dataset, see [Verified Models](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html#verified-models)."
+    "For the accuracy numbers of these models on the ImageNet validation dataset, see [Verified Models](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html#verified-models)."
    ]
   },
   {
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Also see [General Script Usage](https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html#image-class-usage) for more information."
+    "Also see [General Script Usage](https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html#image-class-usage) for more information."
    ]
   },
   {


### PR DESCRIPTION
The location of the TF-TRT docs changed from `https://docs.nvidia.com/deeplearning/dgx/integrate-tf-trt/index.html` to `https://docs.nvidia.com/deeplearning/dgx/tf-trt-user-guide/index.html`.