### PR TITLE
Fixed object detection scripts dependency installation and conversion parameter generation

### DIFF
--- a/tftrt/examples/image_classification/README.md
+++ b/tftrt/examples/image_classification/README.md
@@ -64,7 +64,6 @@ python image_classification.py \
     --calib_data_dir /data/imagenet/train-val-tfrecord \
     --saved_model_dir /models/resnet_v1.5_50_saved_model/ \
     --model resnet_v1.5_50_tfv2 \
-    --mode validation \
     --num_warmup_iterations 50 \
     --num_calib_inputs 128
     --display_every 10 \

--- a/tftrt/examples/object_detection/install_dependencies.sh
+++ b/tftrt/examples/object_detection/install_dependencies.sh
@@ -19,10 +19,10 @@
 set -v
 
 echo Install PyBind11 and UJson
-pip install -y pybind11 ujson
+pip install pybind11 ujson
 
 echo Install Cython...
-pip install -y Cython
+pip install Cython
 
 echo Install cocodataset/cocoapi/PythonAPI...
 COCO_API_DIR=../third_party/cocoapi

--- a/tftrt/examples/object_detection/object_detection.py
+++ b/tftrt/examples/object_detection/object_detection.py
@@ -384,7 +384,7 @@ def get_trt_conversion_params(max_workspace_size_bytes,
                               precision_mode,
                               minimum_segment_size):
     conversion_params = copy.deepcopy(trt.DEFAULT_TRT_CONVERSION_PARAMS)
-    conversion_params = params._replace(
+    conversion_params = conversion_params._replace(
         precision_mode=precision_mode,
         max_workspace_size_bytes=max_workspace_size_bytes,
         minimum_segment_size=minimum_segment_size,


### PR DESCRIPTION
1. Fixes python package installation in dependency installer
2. Fix trt conversion parameter generation as object detection script uses undefined conversion parameter as of now
3. Miscellaneous: Removes unsupported --mode argument from README.md