### PR TITLE
Update container versions and toggle CXX11_ABI flag for CPP examples

### DIFF
--- a/tftrt/benchmarking-cpp/CMakeLists.txt
+++ b/tftrt/benchmarking-cpp/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(tf_trt_benchmark_runner main.cc)
 target_link_libraries(tf_trt_benchmark_runner tensorflow_cc)
 target_link_libraries(tf_trt_benchmark_runner tensorflow_framework)
 
-target_compile_options(tf_trt_benchmark_runner PRIVATE -D_GLIBCXX_USE_CXX11_ABI=0 -DGOOGLE_CUDA -DGOOGLE_TENSORRT)
+target_compile_options(tf_trt_benchmark_runner PRIVATE -D_GLIBCXX_USE_CXX11_ABI=1 -DGOOGLE_CUDA -DGOOGLE_TENSORRT)
 
 target_link_directories(tf_trt_benchmark_runner PRIVATE ${tf_python_dir})
 target_link_directories(tf_trt_benchmark_runner PRIVATE ${tf_dir})

--- a/tftrt/benchmarking-cpp/README.md
+++ b/tftrt/benchmarking-cpp/README.md
@@ -7,13 +7,13 @@ This straightforward example uses TF's C++ API to serve a saved model and measur
 Pull the image:
 
 ```
-docker pull nvcr.io/nvidia/tensorflow:22.05-tf2-py3
+docker pull nvcr.io/nvidia/tensorflow:22.06-tf2-py3
 ```
 
 Start the container:
 
 ```
-docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 -it --name TFTRT_CPP nvcr.io/nvidia/tensorflow:22.05-tf2-py3
+docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 -it --name TFTRT_CPP nvcr.io/nvidia/tensorflow:22.06-tf2-py3
 ```
 
 Clone the repo:

--- a/tftrt/examples-cpp/mnist_demo/CMakeLists.txt
+++ b/tftrt/examples-cpp/mnist_demo/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(tf_trt_example main.cc mnist.h mnist.cc)
 target_link_libraries(tf_trt_example tensorflow_cc)
 target_link_libraries(tf_trt_example tensorflow_framework)
 
-target_compile_options(tf_trt_example PRIVATE -D_GLIBCXX_USE_CXX11_ABI=0 -DGOOGLE_CUDA -DGOOGLE_TENSORRT)
+target_compile_options(tf_trt_example PRIVATE -D_GLIBCXX_USE_CXX11_ABI=1 -DGOOGLE_CUDA -DGOOGLE_TENSORRT)
 
 target_link_directories(tf_trt_example PRIVATE ${tf_python_dir})
 target_link_directories(tf_trt_example PRIVATE ${tf_dir})

--- a/tftrt/examples-cpp/mnist_demo/README.md
+++ b/tftrt/examples-cpp/mnist_demo/README.md
@@ -15,7 +15,7 @@ The MNIST inference example is based on https://github.com/bmzhao/saved-model-ex
 git clone https://github.com/tensorflow/tensorrt.git
 git clone https://github.com/tensorflow/tensorflow.git tensorflow-source
 mkdir bazel-cache
-docker run --gpus=all --rm -it --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 -v $PWD:/workspace -w /workspace -v $PWD/bazel-cache:/root/.cache/bazel nvcr.io/nvidia/tensorflow:21.06-tf2-py3
+docker run --gpus=all --rm -it --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 -v $PWD:/workspace -w /workspace -v $PWD/bazel-cache:/root/.cache/bazel nvcr.io/nvidia/tensorflow:22.06-tf2-py3
 
 # Inside the container
 cp /opt/tensorflow/nvbuild* /opt/tensorflow/bazel_build.sh .


### PR DESCRIPTION
Using recent containers (i.e. 22.06 and later) causes linking errors when attempting to build the C++ examples that use CMake. It appears the TF symbols in the newer containers are tagged with `[abi:cx11]`. Toggling the `_GLIBCXX_USE_CXX11_ABI` macro fixes the linking issues. Creating this PR for this workaround in case this issue pops up in the future.